### PR TITLE
Default calendar view

### DIFF
--- a/src/routes/Calendar.tsx
+++ b/src/routes/Calendar.tsx
@@ -1,17 +1,16 @@
 import { Badge, Button, Caption1, Caption2, Card, Dialog, DialogActions, DialogBody, DialogContent, DialogSurface, DialogTitle, DialogTrigger, Drawer, DrawerBody, DrawerHeader, DrawerHeaderTitle, Subtitle1, Subtitle2, Title3, Tooltip, Tree, TreeItem, TreeItemLayout, makeStyles, mergeClasses, shorthands, tokens } from "@fluentui/react-components";
-import { ArrowExportRegular, CalendarMonthRegular, CalendarWeekNumbersRegular, DismissRegular, SettingsRegular, BackpackFilled, BuildingFilled, PersonFilled, DismissFilled, EyeFilled, EyeOffFilled, StarRegular, StarFilled } from "@fluentui/react-icons";
+import { ArrowExportRegular, BackpackFilled, BuildingFilled, CalendarMonthRegular, CalendarWeekNumbersRegular, DismissFilled, DismissRegular, EyeFilled, EyeOffFilled, PersonFilled, SettingsRegular, StarFilled, StarRegular } from "@fluentui/react-icons";
 import { useContext, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { DateSelector } from "../components/DateSelector";
 import EventDetails from "../components/EventDetails";
 import { CalendarSelection, CalendarSelector, CalendarType, getCalendarSelections } from "../components/calendar/CalendarSelector";
 import { RouterButton } from "../components/router/RouterButton";
-
+import { UserContext } from "../context/UserContext";
 import { EventDto } from "../dto/EventDto";
 import { generateMonth, generateShortWeek, generateWeek } from "../libraries/calendarGenerator/calendarGenerator";
-import useRequests from "../libraries/requests/requests";
 import { useMediaQuery } from "../libraries/mediaQuery/mediaQuery";
-import { UserContext } from "../context/UserContext";
-import { useSearchParams } from 'react-router-dom';
+import useRequests from "../libraries/requests/requests";
 
 const useStyles = makeStyles({
     drawerBody: {
@@ -190,7 +189,7 @@ type Calendar = {
 type ExtendedEventDto = EventDto & {
     color: number;
     selectionId: string;
-}
+};
 
 const COLORS = [
     // special: default course
@@ -207,12 +206,12 @@ const COLORS = [
 
 // Colors that can be randomly selected.
 // The first color is reserved for the default course
-const RANDOMABLE_COLORS = [ ...Array(COLORS.length - 1).keys() ].map(k => k + 1);
+const RANDOMABLE_COLORS = [...Array(COLORS.length - 1).keys()].map(k => k + 1);
 
 export function Calendar() {
     const styles = useStyles();
     const { course } = useContext(UserContext).course;
-    const screenMediaQuery = useMediaQuery('(max-width: 578px)');
+    const screenMediaQuery = useMediaQuery("(max-width: 578px)");
     const requests = useRequests();
     const [isCurrentViewMonth, setIsCurrentViewMonth] = useState<boolean>(true);
 
@@ -224,7 +223,7 @@ export function Calendar() {
         weekDaysAbbr: ["Lun", "Mar", "Mer", "Gio", "Ven", "Sab", "Dom"]
     };
 
-    const [ searchParams, setSearchParams ] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParams();
 
     const [now] = useState(new Date());
     const [dateTime, setDateTime] = useState(new Date(now));
@@ -300,10 +299,10 @@ export function Calendar() {
                     ...event,
                     color: calendar.color,
                     selectionId: calendar.selection.id,
-                }
+                };
 
                 return result;
-            })
+            });
     };
 
     /**
@@ -341,13 +340,13 @@ export function Calendar() {
      */
     function addCalendars(...calendars: Calendar[]) {
         setCalendars((oldValue) => {
-            const newValue = [ ...oldValue ];
+            const newValue = [...oldValue];
             for (const calendar of calendars) {
                 if (!newValue.find(item => item.selection.id === calendar.selection.id)) {
                     newValue.push(calendar);
                 }
             }
-            
+
             if (newValue.length === oldValue.length)
                 return oldValue;
             else
@@ -371,9 +370,9 @@ export function Calendar() {
      * */
     async function onAddCalendarClick() {
         if (!currentSelection) return;
-        
+
         const calendar = createCalendar(currentSelection);
-        
+
         addCalendars(calendar);
     };
 
@@ -401,9 +400,9 @@ export function Calendar() {
         let calendar = await createCalendar(selection);
 
         for (const parameter of split) {
-            if (parameter === 'disabled') {
+            if (parameter === "disabled") {
                 calendar.enabled = false;
-            } else if (parameter.length > 0 && parameter[0] === 'c') {
+            } else if (parameter.length > 0 && parameter[0] === "c") {
                 const colorValue = parseInt(parameter.substring(1));
                 if (colorValue >= 0 && colorValue < COLORS.length) {
                     calendar.color = colorValue;
@@ -503,7 +502,7 @@ export function Calendar() {
                                         }
                                     </div>
                                 </div>
-                            )
+                            );
                         })
                     }
                 </div>
@@ -652,14 +651,14 @@ export function Calendar() {
         } else {
             // No calendars from parameters: try to load the default calendars from local storage
             try {
-                const defaults = window.localStorage.getItem('defaultCalendar');
+                const defaults = window.localStorage.getItem("defaultCalendar");
                 if (defaults !== null) {
                     const parsed = new URLSearchParams(defaults);
                     addCalendars(...await createCalendarsFromSearchParams(parsed));
                     return;
                 }
             } catch (err) {
-                console.warn('Failed to load default calendars from local storage', err);
+                console.warn("Failed to load default calendars from local storage", err);
             }
 
             // No calendars from local storage: add the default course
@@ -667,7 +666,7 @@ export function Calendar() {
         }
     }
 
-    
+
     useEffect(() => {
         loadCalendars();
     }, []);
@@ -681,11 +680,11 @@ export function Calendar() {
     // Update default view state when search parameters change,
     // and save current view as default if no default is set and the current search parameters are not empty
     useEffect(() => {
-        const currentDefault = window.localStorage.getItem('defaultCalendar');
+        const currentDefault = window.localStorage.getItem("defaultCalendar");
         if (currentDefault) {
             setIsDefault(searchParams.toString() === currentDefault);
         } else if (searchParams.size !== 0) {
-            window.localStorage.setItem('defaultCalendar', searchParams.toString());
+            window.localStorage.setItem("defaultCalendar", searchParams.toString());
             setIsDefault(true);
         }
     }, [searchParams]);
@@ -695,7 +694,7 @@ export function Calendar() {
         calendars.forEach(async (calendar) => {
             const newEvents = await getEvents(calendar);
             setEvents((oldValue) => [...oldValue, ...newEvents]);
-        })
+        });
     }, [dateTime, calendars]);
 
     return (
@@ -705,7 +704,7 @@ export function Calendar() {
                 <div className={styles.stack}>
                     <Subtitle2>{calendarTitle}</Subtitle2>
                     <Tooltip
-                        content={isDefault ? 'Questa è la visualizzazione predefinita' : 'Imposta come visualizzazione predefinita'}
+                        content={isDefault ? "Questa è la visualizzazione predefinita" : "Imposta come visualizzazione predefinita"}
                         relationship="description"
                     >
                         <Button
@@ -713,7 +712,7 @@ export function Calendar() {
                             disabled={isDefault}
                             onClick={() => {
                                 if (!isDefault) {
-                                    window.localStorage.setItem('defaultCalendar', searchParams.toString());
+                                    window.localStorage.setItem("defaultCalendar", searchParams.toString());
                                     setIsDefault(true);
                                 }
                             }}
@@ -742,7 +741,7 @@ export function Calendar() {
                     </div>
                 </div>
 
-                <Drawer type={window.matchMedia('(max-width: 1000px)').matches ? "overlay" : "inline"} open={isDrawerOpen} onOpenChange={(_, { open }) => setIsDrawerOpen(open)} position="end" className={styles.drawer}>
+                <Drawer type={window.matchMedia("(max-width: 1000px)").matches ? "overlay" : "inline"} open={isDrawerOpen} onOpenChange={(_, { open }) => setIsDrawerOpen(open)} position="end" className={styles.drawer}>
                     <DrawerHeader>
                         <DrawerHeaderTitle
                             action={


### PR DESCRIPTION
Aggiunge la possibilità di selezionare una visualizzazione predefinita per il calendario.

La selezione viene salvata in localStorage nella chiave `defaultCalendar`. Il valore è la querystring.

Se non è definito un calendario predefinito, verrà automaticamente impostato come predefinito il calendario aggiunto da `onAddCalendarClick()` (quindi il calendario del corso dell'utente).