### PR TITLE
Prioritize calendar syncing over viewing

### DIFF
--- a/src/components/router/RouterMenu.tsx
+++ b/src/components/router/RouterMenu.tsx
@@ -64,7 +64,7 @@ const menuItems = [
   },
   {
     displayName: "Calendario",
-    path: "/calendar",
+    path: "/calendar-sync",
     isSelected: (p: string) => /^\/calendar.*/g.test(p),
     icon: <CalendarFilled />,
   },

--- a/src/components/router/RouterMenu.tsx
+++ b/src/components/router/RouterMenu.tsx
@@ -65,6 +65,7 @@ const menuItems = [
   {
     displayName: "Calendario",
     path: "/calendar",
+    isSelected: (p: string) => /^\/calendar.*/g.test(p),
     icon: <CalendarFilled />,
   },
   {
@@ -78,10 +79,10 @@ const RouterMenu: FunctionComponent<TabListProps> = (props, iconsOnly: boolean) 
   const styles = useStyles();
   const { logout } = useContext(UserContext);
 
-  useLocation();
-  const currentUrl = new URL(window.location.href);
-  const path = currentUrl.pathname;
+  const { pathname } = useLocation();
   const navigate = useNavigate();
+
+  const selected = menuItems.find((i) => (i.isSelected ? i.isSelected(pathname) : i.path === pathname));
 
   const [isUserDrawerOpen, setIsUserDrawerOpen] = useState(false);
 
@@ -96,14 +97,14 @@ const RouterMenu: FunctionComponent<TabListProps> = (props, iconsOnly: boolean) 
 
           const url = new URL(data.value, window.location.href);
           if (url.origin === window.location.origin) {
-            if (currentUrl.pathname !== url.pathname) {
+            if (location.pathname !== url.pathname) {
               navigate(url.href.substring(url.origin.length));
             }
           } else {
             window.open(url);
           }
         }}
-        selectedValue={path}>
+        selectedValue={selected?.path}>
         {menuItems.map((item, i) => {
           return (
             <Tab key={i} value={item.path} icon={item.icon} aria-description={item.displayName}>

--- a/src/routes/CalendarExport.tsx
+++ b/src/routes/CalendarExport.tsx
@@ -11,6 +11,7 @@ import {
 } from "@fluentui/react-components";
 import { CalendarExporter } from "../components/calendar/CalendarExporter";
 import { useGlobalStyles } from "../globalStyles";
+import { RouterButton } from "../components/router/RouterButton.tsx";
 
 const useStyles = makeStyles({
   warning: {
@@ -67,6 +68,10 @@ export function CalendarExport() {
               <strong>I link generati contengono informazioni personali. Non condividerli con nessuno.</strong>
             </Body1>
           </Card>
+          <Body1>In alternativa, puoi visualizzare il calendario qui.</Body1>
+          <RouterButton as="a" appearance="primary" href="/calendar">
+            Visualizza calendario su {window.location.hostname}
+          </RouterButton>
         </div>
       </div>
     </>


### PR DESCRIPTION
Cliccando su "Calendario" nel menu viene ora visualizzata la pagina di sincronizzazione invece del calendario.

Alla pagina di sincronizzazione ho aggiunto un pulsante che passa al calendario.

https://github.com/Project-Betoniera/Project-Betoniera-Frontend/assets/4389687/c2a6aa08-f2a3-4223-bd5b-c81bddb1965b

(Il testo si basa su `window.location.hostname`, quando deployato quindi verrebbe mostrato `betoniera.org`)